### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 ## [vxx](https://github.com/singularityware/singularity-python/tree/development) (development)
 
+**changed user experience**
+ - to address this [sregisty issue](https://github.com/singularityhub/sregistry/issues/56) the push client does not always state that the upload is finished. In the case that an image is frozen (and 403 status) this message is misleading.
 
 ## [v2.4.1](https://github.com/singularityware/singularity-python/releases/tag/v2.4.1) (v2.4.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and changes prior to that are (unfortunately) done retrospectively. Critical ite
 
 **changed user experience**
  - to address this [sregisty issue](https://github.com/singularityhub/sregistry/issues/56) the push client does not always state that the upload is finished. In the case that an image is frozen (and 403 status) this message is misleading.
+**pull bug**
+ - changing function to rename image after download to `shutil.move` to allow for cross device downloads.
 
 ## [v2.4.1](https://github.com/singularityware/singularity-python/releases/tag/v2.4.1) (v2.4.1)
 

--- a/Singularity.container
+++ b/Singularity.container
@@ -25,6 +25,6 @@ git clone -b development https://www.github.com/vsoch/singularity-python
 cd singularity-python
 /opt/conda/bin/pip install setuptools
 /opt/conda/bin/pip install -r requirements.txt
-/opt/conda/bin/pip install pyasn1==0.3.4
+/opt/conda/bin/pip install pyasn1==0.4.1
 /opt/conda/bin/python setup.py sdist
 /opt/conda/bin/python setup.py install

--- a/examples/docker/.dockerignore
+++ b/examples/docker/.dockerignore
@@ -1,0 +1,7 @@
+examples/*
+examples
+build
+*.simg
+*.img
+dist
+*.egg.info

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -15,4 +15,5 @@ RUN /opt/conda/bin/pip install setuptools && \
     /opt/conda/bin/pip install -r requirements.txt && \
     /opt/conda/bin/pip install pyasn1==0.4.1 && \
     /opt/conda/bin/python setup.py sdist && \
-    /opt/conda/bin/python setup.py install
+    /opt/conda/bin/python setup.py install && \
+    apt-get clean

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM continuumio/miniconda3
+
+# docker build -t vanessa/singularity-python .
+
+ENV PATH /opt/conda/bin:$PATH
+LABEL maintainer vsochat@stanford.edu
+
+RUN apt-get update && apt-get install -y git && \
+    /opt/conda/bin/conda install -y numpy scikit-learn cython pandas
+
+WORKDIR /opt
+RUN git clone -b development https://www.github.com/vsoch/singularity-python
+WORKDIR singularity-python
+RUN /opt/conda/bin/pip install setuptools && \
+    /opt/conda/bin/pip install -r requirements.txt && \
+    /opt/conda/bin/pip install pyasn1==0.4.1 && \
+    /opt/conda/bin/python setup.py sdist && \
+    /opt/conda/bin/python setup.py install

--- a/examples/docker/Dockerfile.shub
+++ b/examples/docker/Dockerfile.shub
@@ -1,0 +1,3 @@
+FROM vanessa/singularity-python:2.4.1
+LABEL VERSION 2.4.1
+CMD ["/opt/conda/bin/shub"]

--- a/examples/docker/Dockerfile.sregistry
+++ b/examples/docker/Dockerfile.sregistry
@@ -1,0 +1,3 @@
+FROM vanessa/singularity-python:2.4.1
+LABEL VERSION 2.4.1
+CMD ["/opt/conda/bin/sregistry"]

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,40 @@
+# Docker images
+
+These docker images are meant to provide a client for [Singularity Hub](Dockerfile.shub)
+and [Singularity Registry](Dockerfile.sregistry), respectively. These images are provided on [Docker Hub](https://hub.docker.com/r/vanessa/singularity-python/).
+
+
+## Singuarity Python Base
+
+**build**
+```
+docker build -t vanessa/singularity-python .
+docker tag vanessa/singularity-python vanessa/singularity-python:2.4.1
+docker push vanessa/singularity-python:2.4.1
+```
+
+## Singularity Client
+
+**build**
+```
+docker build -f Dockerfile.shub -t vanessa/singularity-python:shub-2.4.1 .
+docker push vanessa/singularity-python:shub-2.4.1
+```
+
+**usage**
+```
+docker run vanessa/singularity-python:shub-2.4.1
+```
+
+## Singularity Registry Client
+
+**build**
+```
+docker build -f Dockerfile.sregistry -t vanessa/singularity-python:sreg-2.4.1 .
+docker push vanessa/singularity-python:sreg-2.4.1
+```
+
+**usage**
+```
+docker run vanessa/singularity-python:sreg-2.4.1
+```

--- a/singularity/hub/__init__.py
+++ b/singularity/hub/__init__.py
@@ -27,6 +27,7 @@ SOFTWARE.
 from requests.exceptions import HTTPError
 
 from singularity.logger import bot
+import shutil
 import requests
 import tempfile
 import json
@@ -154,7 +155,7 @@ class ApiConnection(object):
         if isinstance(response, HTTPError):
             bot.error("Error downloading %s, exiting." %url)
             sys.exit(1)
-        os.rename(tmp_file, file_name)
+        shutil.move(tmp_file, file_name)
         return file_name
 
 

--- a/singularity/registry/client/push.py
+++ b/singularity/registry/client/push.py
@@ -129,7 +129,7 @@ def push(self, path, name, tag=None, compress=False):
         r = requests.post(url, data=monitor, headers=headers)
         message = self.read_response(r)
 
-        print('\nUpload finished! [Return status {0} {1}]'.format(r.status_code, message))
+        print('\n[Return status {0} {1}]'.format(r.status_code, message))
 
     except KeyboardInterrupt:
         print('\nUpload cancelled.')


### PR DESCRIPTION
Quick updates to do the following:
 - allow cross device downloads by using shutil.move instead of os.rename
 - remove misleading error message for sregistry